### PR TITLE
Use TypeInh to support derived type search

### DIFF
--- a/opencog/pln/rules/intensional/attraction-introduction.scm
+++ b/opencog/pln/rules/intensional/attraction-introduction.scm
@@ -27,7 +27,7 @@
 (define subset-attraction-introduction-rule
   (let* ((A (Variable "$A"))
          (B (Variable "$B"))
-         (CT (Type "ConceptNode")))
+         (CT (TypeInh "ConceptNode")))
     (BindLink
       (VariableSet
         (TypedVariable A CT)

--- a/opencog/pln/rules/intensional/intensional-difference-direct-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-difference-direct-introduction.scm
@@ -67,7 +67,7 @@
   (let* ((A (Variable "$A"))
          (B (Variable "$B"))
          (X (Variable "$X"))
-         (CT (Type "ConceptNode")))
+         (CT (TypeInh "ConceptNode")))
     (Bind
       (VariableSet
         (TypedVariable A CT)

--- a/opencog/pln/rules/intensional/intensional-difference-member-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-difference-member-introduction.scm
@@ -30,7 +30,7 @@
   (let* ((A (Variable "$A"))
          (B (Variable "$B"))
          (X (Variable "$X"))
-         (CT (Type "ConceptNode")))
+         (CT (TypeInh "ConceptNode")))
     (Bind
       (VariableSet
         (TypedVariable A CT)

--- a/opencog/pln/rules/intensional/intensional-inheritance-direct-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-inheritance-direct-introduction.scm
@@ -71,7 +71,7 @@
   (let* ((A (Variable "$A"))
          (B (Variable "$B"))
          (X (Variable "$X"))
-         (CT (Type "ConceptNode")))
+         (CT (TypeInh "ConceptNode")))
     (Bind
       (VariableSet
         (TypedVariable A CT)

--- a/opencog/pln/rules/intensional/intensional-similarity-direct-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-similarity-direct-introduction.scm
@@ -67,7 +67,7 @@
   (let* ((A (Variable "$A"))
          (B (Variable "$B"))
          (X (Variable "$X"))
-         (CT (Type "ConceptNode")))
+         (CT (TypeInh "ConceptNode")))
     (Bind
       (VariableSet
         (TypedVariable A CT)


### PR DESCRIPTION
Enables type search for all new types derived from ConceptNode. Tested with the experiment https://github.com/singnet/reasoning-bio-as-xp/tree/bioAtomspace-v2 for IntensionalSimilarity and IntensionalInheritance of GO terms. 