### PR TITLE
Undeclare atom types already declared in spacetime

### DIFF
--- a/opencog/pln/types/atom_types.script
+++ b/opencog/pln/types/atom_types.script
@@ -10,22 +10,15 @@ INTENSIONAL_DIFFERENCE_LINK <- ORDERED_LINK,EVALUATABLE_LINK
 
 // Temporal Reasoning
 
-// Warning: some of these links are already defined in the opencog
-// repository, see
-//
-// opencog/opencog/nlp/types/atom_types.script
-//
-// and the spacetime repository, see
+// For the definition of these links see
+// https://wiki.opencog.org/w/Category:Atom_Types
+PREDICTIVE_IMPLICATION_SCOPE_LINK <- SCOPE_LINK
+
+// These links are already declared in the spacetime repository, see
 //
 // spacetime/opencog/spacetime/atom-types/atom_types.script.
 //
-// Also note that SequentialAnd and SequentialOr are already defined
-// in the atomspace repository.
-
-// For the definition of these links see
-// https://wiki.opencog.org/w/Category:Atom_Types
-AT_TIME_LINK <- ORDERED_LINK
-TIME_INTERVAL_LINK <- ORDERED_LINK
-TIME_NODE <- NODE
-PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK
-PREDICTIVE_IMPLICATION_SCOPE_LINK <- SCOPE_LINK
+// AT_TIME_LINK <- ORDERED_LINK
+// TIME_INTERVAL_LINK <- ORDERED_LINK
+// TIME_NODE <- NODE
+// PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK


### PR DESCRIPTION
to avoid collision between pln and spacetime modules.