### PR TITLE
Add util functions to load rules from files not in the load path

### DIFF
--- a/opencog/pln/pln-utils.scm
+++ b/opencog/pln/pln-utils.scm
@@ -28,6 +28,24 @@
   ;; Avoid confusing the user with a return value
   *unspecified*)
 
+(define-public (pln-load-from-file FILENAME)
+"
+  pln-load-from-file FILENAME
+
+  Like primitive-load but load the content into pln-atomspace. Used to
+  load PLN rules that are not in the load path without polluting the current atomspace.
+"
+  ;; Switch to PLN atomspace
+  (define current-as (cog-set-atomspace! pln-atomspace))
+
+  (primitive-load FILENAME)
+
+  ;; Switch back to previous space
+  (cog-set-atomspace! current-as)
+
+  ;; Avoid confusing the user with a return value
+  *unspecified*)
+
 (define-public (pln-rule-type->filename RULE-TYPE)
 "
   pln-rule-type->filename RULE-TYPE


### PR DESCRIPTION
The `pln-load-from-file` loads rules from a file that is not in the load path. This can be useful when we are calling this from a guile module and the rule isn't in that module's load-path.