### PR TITLE
Type support for subset introduction rule

### DIFF
--- a/opencog/pln/rules/extensional/subset-direct-introduction.scm
+++ b/opencog/pln/rules/extensional/subset-direct-introduction.scm
@@ -16,7 +16,7 @@
 (define subset-direct-introduction-rule
   (let* ((A (Variable "$A"))
          (B (Variable "$B"))
-         (CptT (Type 'Concept))
+         (CptT (TypeInh 'Concept))
          (AndT (Type 'And)))
     (Bind
       (VariableSet


### PR DESCRIPTION
Enable the subset introduction rule to look down to other types inherited from ConceptNode.